### PR TITLE
[ENG-633] fix the getAlternateSourceStats method on broken join

### DIFF
--- a/Entity/LedgerEntryRepository.php
+++ b/Entity/LedgerEntryRepository.php
@@ -357,7 +357,7 @@ class LedgerEntryRepository extends CommonRepository
         $ledgerBuilder
             ->leftJoin('l', '('.$costRevenueBuilder->getSQL().')', 'cl', 'l.id = cl.contact_id')
             ->leftJoin('l', '('.$convertedBuilder->getSQL().')', 'cc', 'l.id = cc.contact_id')
-            ->leftJoin('l', 'campaign_leads', 'cal', 'cal.campaign_id = l.id')
+            ->leftJoin('l', 'campaign_leads', 'cal', 'cal.lead_id = c.id')
             ->leftJoin('cal', 'campaigns', 'c', 'cal.campaign_id = c.id');
 
         $ledgerBuilder


### PR DESCRIPTION
Also run this query after code deploy, to flag records for re-processing

```
update `contact_ledger_campaign_source_stats` set reprocess_flag = 1
where date_added between '2018-10-04 00:00:00' AND '2018-10-29 23:59:59'
```

where the second date is whenever the code is deployed.