### PR TITLE
Replace persist+flush with saveEntities and clear.

### DIFF
--- a/Command/ClientStatsCommand.php
+++ b/Command/ClientStatsCommand.php
@@ -161,6 +161,7 @@ class ClientStatsCommand extends ModeratedCommand implements ContainerAwareInter
                 $this->dispatcher->dispatch('mautic.contactledger.clientstats.generate', $event);
 
                 // save entities to DB
+                $entities = [];
                 foreach ($event->getStatsCollection() as $subscriber) {
                     $output->writeln(
                         '<info>--> Pesisting data for '.$context.' using date '.$this->dateContext->format(
@@ -169,12 +170,12 @@ class ClientStatsCommand extends ModeratedCommand implements ContainerAwareInter
                     );
                     if (isset($subscriber[$context]) && !empty($subscriber[$context])) {
                         foreach ($subscriber[$context] as $stat) {
-                            $entity = $this->mapArrayToEntity($stat, $context, $this->dateContext);
-                            $this->em->persist($entity);
+                            $entities[] = $this->mapArrayToEntity($stat, $context, $this->dateContext);
                         }
                     }
-                    $this->em->flush(CampaignClientStats::class);
                 }
+                $repo->saveEntities($entities);
+                $this->em->clear(CampaignClientStats::class);
             } else {
                 $output->writeln('<comment>--> Data already Exists: '.$this->dateContext->format('Y-m-d H:i:s').'.</comment>');
 

--- a/Command/ReportReprocessCommand.php
+++ b/Command/ReportReprocessCommand.php
@@ -13,7 +13,9 @@ namespace MauticPlugin\MauticContactLedgerBundle\Command;
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Command\ModeratedCommand;
 use MauticPlugin\MauticContactLedgerBundle\Entity\CampaignClientStats;
+use MauticPlugin\MauticContactLedgerBundle\Entity\CampaignClientStatsRepository;
 use MauticPlugin\MauticContactLedgerBundle\Entity\CampaignSourceStats;
+use MauticPlugin\MauticContactLedgerBundle\Entity\CampaignSourceStatsRepository;
 use MauticPlugin\MauticContactLedgerBundle\Entity\LedgerEntryRepository;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -279,6 +281,7 @@ class ReportReprocessCommand extends ModeratedCommand implements ContainerAwareI
                 );
 
                 // 2) Get entities that match date_added
+                /** @var CampaignSourceStatsRepository */
                 $entitiesToReprocess = $this->getEntitiesToReprocess($params, 'MauticContactLedgerBundle:CampaignSourceStats');
                 foreach ($entitiesToReprocess as $entityToDelete) {
                     $this->em->remove($entityToDelete);
@@ -287,14 +290,19 @@ class ReportReprocessCommand extends ModeratedCommand implements ContainerAwareI
                 // 3) reprocess data using this new date criteria
                 $statData = $this->getCampaignSourceStatsData($params);
 
+                $entities = [];
                 foreach ($statData as $stat) {
                     $entity = $this->mapSourceArrayToEntity($stat, $params['dateTo']);
                     $entity->setReprocessFlag(false);
-                    $this->em->persist($entity);
+                    $entities[] = $entity;
                 }
 
                 // 5) flush and repeat
-                $this->em->flush(CampaignSourceStats::class);
+                /** @var CampaignSourceStatsRepository $repo */
+                $repo = $this->em->getRepository('MauticContactLedgerBundle:CampaignSourceStats');
+                $repo->saveEntities($entities);
+                $this->em->clear(CampaignSourceStats::class);
+
                 $timeContext = microtime(true);
                 $contextTime = $timeContext - $timeStart;
                 $batchRun    = $timeContext - $batchStart;
@@ -349,13 +357,18 @@ class ReportReprocessCommand extends ModeratedCommand implements ContainerAwareI
                 // 3) reprocess data using this new date criteria
                 $statData = $this->getCampaignClientStatsData($params);
 
+                $entities = [];
                 foreach ($statData as $stat) {
                     $entity = $this->mapClientArrayToEntity($stat, $params['dateTo']);
                     $entity->setReprocessFlag(false);
-                    $this->em->persist($entity);
+                    $entities[] = $entity;
                 }
 
-                $this->em->flush(CampaignClientStats::class);
+                /** @var CampaignClientStatsRepository $repo */
+                $repo = $this->em->getRepository('MauticContactLedgerBundle:CampaignClientStats');
+                $repo->saveEntities($entities);
+                $this->em->clear(CampaignClientStats::class);
+
                 $timeContext = microtime(true);
                 $contextTime = $timeContext - $timeStart;
                 $batchRun    = $timeContext - $batchStart;

--- a/Command/ReportReprocessCommand.php
+++ b/Command/ReportReprocessCommand.php
@@ -281,7 +281,6 @@ class ReportReprocessCommand extends ModeratedCommand implements ContainerAwareI
                 );
 
                 // 2) Get entities that match date_added
-                /** @var CampaignSourceStatsRepository */
                 $entitiesToReprocess = $this->getEntitiesToReprocess($params, 'MauticContactLedgerBundle:CampaignSourceStats');
                 foreach ($entitiesToReprocess as $entityToDelete) {
                     $this->em->remove($entityToDelete);

--- a/EventListener/CampaignSourceStatsSubscriber.php
+++ b/EventListener/CampaignSourceStatsSubscriber.php
@@ -11,6 +11,7 @@
 
 namespace MauticPlugin\MauticContactLedgerBundle\EventListener;
 
+use MauticPlugin\MauticContactLedgerBundle\Entity\LedgerEntryRepository;
 use MauticPlugin\MauticContactLedgerBundle\Event\ReportStatsGeneratorEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -38,6 +39,7 @@ class CampaignSourceStatsSubscriber implements EventSubscriberInterface
             //first check to see if the table has any records in the params range
             // do this before running the more intensive query below
 
+            /** @var LedgerEntryRepository $repo */
             $repo = $em->getRepository(\MauticPlugin\MauticContactLedgerBundle\Entity\LedgerEntry::class);
 
             $data = $repo->getCampaignSourceStatsData(


### PR DESCRIPTION
| Risk Level                                | No | Low | High |
| ----------------------------------------- | -- | --- | ---- |
| Alters Lead Data?                         |  X  |     |      |
| Schema Change?                            |  X  |     |      |
| Adds A Query or Modifies Existing Query?  |    |   X  |      |
| Adds or Modifies Existing Auto-Enhancer?  |    |     |      |
| Modifies Ingestion Process?               |    |     |      |
| Modifies sendContact Data?                |    |     |      |


[//]: # ( Required: )
#### Description:
Fixes:
```
[2019-06-19 19:45:07] mautic.NOTICE: Doctrine\DBAL\Exception\DriverException: An exception occurred while executing 'INSERT INTO contact_ledger_campaign_source_stats (date_added, campaign_id, contact_source_id, cost, revenue, gross_income, margin, ecpm, received, scrubbed, declined, converted, utm_source, reprocess_flag) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)':  SQLSTATE[HY093]: Invalid parameter number: no parameters were bound (uncaught exception) at /var/app/current/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 115 while running console command `mautic:ledger:source:stats` [] []
[2019-06-19 19:45:07] mautic.WARNING: Command `mautic:ledger:source:stats` exited with status code 1 [] []
```